### PR TITLE
fix overlapping accesses to array issue

### DIFF
--- a/QuickSort.playground/Contents.swift
+++ b/QuickSort.playground/Contents.swift
@@ -1,18 +1,14 @@
 //: Playground - noun: a place where people can play
 
-func swap<T: Comparable>(leftValue: inout T, rightValue: inout T) {
-    (leftValue, rightValue) = (rightValue, leftValue)
-}
-
 func partition<T: Comparable>(array: inout [T], startIndex: Int, endIndex: Int) -> Int {
     var q = startIndex
     for index in startIndex..<endIndex {
         if array[index] < array[endIndex] {
-            swap(leftValue: &array[q], rightValue: &array[index])
+			array.swapAt(q, index)
             q += 1
         }
     }
-    swap(leftValue: &array[q], rightValue: &array[endIndex])
+	array.swapAt(q, endIndex)
     
     return q
 }

--- a/QuickSort.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/QuickSort.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Was unable to run the playground because of overlapping access to the array inout variable.

Replaced swap function with built in "swapAt" function which achieves the same result.